### PR TITLE
Transition Behaviours Extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,16 +254,41 @@ Transition Behaviours allow you to define what EC should do at these transition 
 
 **Use Case:**
 > One use case for this is when lights turn on just before the end of the active period and then they never turn off because EC is constrained. For me, the light would be triggered by me walking into a room at 
-7am and the constrain period would begin at 7:16am. Since the light duration is 20 minutes, EC will never turn off the light because it is in `constrained` state at 7:20am. This is annoying because the lights stay on all day. I can use `end_time_action: "off"` to turn off all lights at 7:16am.
+7am and the constrain period would begin at 7:16am. Since the light duration is 20 minutes, EC will never turn off the light because it is in `constrained` state at 7:20am. This is annoying because the lights stay on all day. I can use `on_enter_constrained: "off"` to turn off all lights at 7:16am (when the EC is constrained).
 
+```
+transition_behaviours:   # light triggers on then off
+    entities: 
+      - input_boolean.lamp
+    sensors:
+      - sensor.motion_sensor
+    overrides:
+      - input_boolean.override_switch
+    delay: 5
+    behaviours:
+      on_enter_constrained: "on"
+    start_time: sunset
+    end_time: "7:16:00"
+```
+**Notes about light flicker:** This can cause light flicker particularly for the `on_exit_*` behaviours. If your lights flicker, make sure you understand how this configuration is impacting them and use the `on_enter_*` behaviours instead.
 
+ 
 #### Supported transition points:  
-More will be added in the future.
+The following behaviours can be defined using the values `"on"`, `"off"` and the default being `"ignore"`. These must be in quotes to avoidconflicts with YAML truth values.
+
 
 |Key|Description|
 |---|---|
-|start_time_action|Triggered at the beginning of active period|
-|end_time_action|Triggered at the end of active period|
+|on_enter_idle||
+|on_exit_idle||
+|on_enter_active||
+|on_exit_active||
+|on_enter_overidden||
+|on_exit_overidden||
+|on_enter_constrained||
+|on_exit_constrained||
+|on_enter_blocked||
+|on_exit_blocked||
 
 #### Supported transition behaviours:  
 You must put these in quotes.

--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -205,32 +205,32 @@ async def async_setup(hass, config):
     )  # re-entering self-transition (on_enter callback executed.)
 
     # Overridden
-    machine.add_transition(trigger='enable', source='overridden', dest='idle')
-    # machine.add_transition(
-    #     trigger="enable",
-    #     source="overridden",
-    #     dest="idle",
-    #     conditions=["is_state_entities_off"],
-    # )
-    # # If a device leaving overridden is on, we do not necessarily want to shut it off immediately. We simply want EC to stop controlling it. To do that, we'll move it to active, to simulate an EC trigger, and we'll see if it exits on its own. This works for event sensors, of course, and it will also work for duration sensors if the current state is on. A duration sensor that is off now will never expire on its own, though, so in that case, we'll assume the target is 'idle'.
-    # machine.add_transition(
-    #     trigger="enable",
-    #     source="overridden",
-    #     dest="active",
-    #     conditions=["is_state_entities_on", "is_event_sensor"],
-    # )
-    # machine.add_transition(
-    #     trigger="enable",
-    #     source="overridden",
-    #     dest="active",
-    #     conditions=["is_state_entities_on", "is_sensor_on"],
-    # )  # This could be duration && on, but it will also work for any event sensor, so it's simpler to just write 'on'
-    # machine.add_transition(
-    #     trigger="enable",
-    #     source="overridden",
-    #     dest="idle",
-    #     conditions=["is_state_entities_on", "is_duration_sensor", "is_sensor_off"],
-    # )
+    # machine.add_transition(trigger='enable', source='overridden', dest='idle')
+    machine.add_transition(
+        trigger="enable",
+        source="overridden",
+        dest="idle",
+        conditions=["is_state_entities_off"],
+    )
+    # If a device leaving overridden is on, we do not necessarily want to shut it off immediately. We simply want EC to stop controlling it. To do that, we'll move it to active, to simulate an EC trigger, and we'll see if it exits on its own. This works for event sensors, of course, and it will also work for duration sensors if the current state is on. A duration sensor that is off now will never expire on its own, though, so in that case, we'll assume the target is 'idle'.
+    machine.add_transition(
+        trigger="enable",
+        source="overridden",
+        dest="active",
+        conditions=["is_state_entities_on", "is_event_sensor"],
+    )
+    machine.add_transition(
+        trigger="enable",
+        source="overridden",
+        dest="active",
+        conditions=["is_state_entities_on", "is_sensor_on"],
+    )  # This could be duration && on, but it will also work for any event sensor, so it's simpler to just write 'on'
+    machine.add_transition(
+        trigger="enable",
+        source="overridden",
+        dest="idle",
+        conditions=["is_state_entities_on", "is_duration_sensor", "is_sensor_off"],
+    )
 
 
     machine.add_transition(
@@ -269,28 +269,27 @@ async def async_setup(hass, config):
         dest="idle",
         conditions=["is_duration_sensor", "is_sensor_off"],
     )
-    machine.add_transition(trigger='block_timer_expires', source='blocked',
-    dest='idle')
-    # machine.add_transition(
-    #     trigger="block_timer_expires",
-    #     source="blocked",
-    #     dest="active",
-    #     conditions=["is_state_entities_on", "is_event_sensor"],
-    # )
-    # machine.add_transition(
-    #     trigger="block_timer_expires",
-    #     source="blocked",
-    #     dest="active",
-    #     conditions=["is_state_entities_on", "is_sensor_on"],
-    # )  # This could be duration && on, but it will also work for any event sensor, so it's simpler to just write 'on'
-    # machine.add_transition(
-    #     trigger="block_timer_expires",
-    #     source="blocked",
-    #     dest="idle",
-    #     conditions=["is_state_entities_on", "is_duration_sensor", "is_sensor_off"],
-    # )
+    # machine.add_transition(trigger='block_timer_expires', source='blocked', dest='idle')
+    machine.add_transition(
+        trigger="block_timer_expires",
+        source="blocked",
+        dest="active",
+        conditions=["is_state_entities_on", "is_event_sensor"],
+    )
+    machine.add_transition(
+        trigger="block_timer_expires",
+        source="blocked",
+        dest="active",
+        conditions=["is_state_entities_on", "is_sensor_on"],
+    )  # This could be duration && on, but it will also work for any event sensor, so it's simpler to just write 'on'
+    machine.add_transition(
+        trigger="block_timer_expires",
+        source="blocked",
+        dest="idle",
+        conditions=["is_state_entities_on", "is_duration_sensor", "is_sensor_off"],
+    )
 
-
+    # Active Timer
     machine.add_transition(
         trigger="control",
         source="active_timer",

--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -1,4 +1,21 @@
 """
+This file is part of Entity Controller.
+
+Entity Controller is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Entity Controller is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Entity Controller.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+"""
 Entity controller component for Home Assistant.
 Maintainer:       Daniel Mason
 Version:          v6.0.0

--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -585,6 +585,31 @@ class Model:
         )
         # This can be called with either a state change or an attribute change. If the state changed, we definitely want to handle the transition. If only attributes changed, we'll check if the new attributes are significant (i.e., not being ignored).
         try:
+            # kept in case it causes problems
+            # if old.state == new.state:  # Only attributes changed
+            #     # Build two dictionaries of attributes, excluding the ones we don't want to monitor
+            #     old_temp = {
+            #         key: old.attributes[key]
+            #         for key in old.attributes
+            #         if key not in self.state_attributes_ignore
+            #     }
+            #     new_temp = {
+            #         key: new.attributes[key]
+            #         for key in new.attributes
+            #         if key not in self.state_attributes_ignore
+            #     }
+            #     if old_temp == new_temp:
+            #         self.log.debug("insignificant attribute only change")
+            #         return
+            #     self.log.debug("significant attribute only change")
+        # except AttributeError as a:
+            # Most likely one of the states, either new or old, is 'off', so there's no attributes dict attached to the state object.
+            # self.log.debug(
+            #     "Most likely one of the states, either new or old, is 'off', so there's no attributes dict attached to the state object: "
+            #     + str(a)
+            # )
+            # pass
+
             if not old or not new or old == 'off' or new == 'off':
                 pass
             else:
@@ -604,11 +629,11 @@ class Model:
                         self.log.debug("insignificant attribute only change")
                         return
                     self.log.debug("significant attribute only change")
-        except Exception as e:
+        except AttributeError as a:
             # Most likely one of the states, either new or old, is 'off', so there's no attributes dict attached to the state object.
             self.log.debug(
                 "Most likely one of the states, either new or old, is 'off', so there's no attributes dict attached to the state object: "
-                + str(e)
+                + str(a)
             )
 
         if self.is_active_timer():

--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -53,8 +53,6 @@ from .const import (
 
     CONF_START_TIME,
     CONF_END_TIME,
-    CONF_END_TIME_ACTION,
-    CONF_START_TIME_ACTION,
     CONF_TRANSITION_BEHAVIOUR_ON,
     CONF_TRANSITION_BEHAVIOUR_OFF,
     CONF_TRANSITION_BEHAVIOUR_IGNORE,
@@ -135,12 +133,6 @@ ENTITY_SCHEMA = vol.Schema(
         vol.Optional(CONF_SENSOR_TYPE_DURATION, default=False): cv.boolean,
         vol.Optional(CONF_SENSOR_TYPE, default=SENSOR_TYPE_EVENT): vol.All(
             vol.Lower, vol.Any(SENSOR_TYPE_EVENT, SENSOR_TYPE_DURATION)
-        ),
-        vol.Optional(CONF_START_TIME_ACTION, default=CONF_TRANSITION_BEHAVIOUR_IGNORE): vol.All(
-            vol.Lower, vol.Any(CONF_TRANSITION_BEHAVIOUR_ON, CONF_TRANSITION_BEHAVIOUR_OFF, CONF_TRANSITION_BEHAVIOUR_IGNORE)
-        ),
-        vol.Optional(CONF_END_TIME_ACTION, default=CONF_TRANSITION_BEHAVIOUR_IGNORE): vol.All(
-            vol.Lower, vol.Any(CONF_TRANSITION_BEHAVIOUR_ON, CONF_TRANSITION_BEHAVIOUR_OFF, CONF_TRANSITION_BEHAVIOUR_IGNORE)
         ),
         vol.Optional(CONF_SENSOR_RESETS_TIMER, default=False): cv.boolean,
         vol.Optional(CONF_SENSOR, default=[]): cv.entity_ids,
@@ -1083,14 +1075,7 @@ class Model:
                     "Constrain period active. Scheduling transition to 'constrained'"
                 )
                 event.async_call_later(self.hass, 1, self.constrain_entity)
-            if CONF_END_TIME_ACTION in config:
-                self.store_transition_behaviour(CONF_END_TIME_ACTION, config.get(CONF_END_TIME_ACTION))
-            if CONF_START_TIME_ACTION in config:
-                self.store_transition_behaviour(CONF_START_TIME_ACTION, config.get(CONF_START_TIME_ACTION))
 
-        else:
-            if CONF_END_TIME_ACTION in config or CONF_START_TIME_ACTION in config:
-                self.log.error("You must define %s and %s in your config to use the %s or %s feature." % (CONF_START_TIME, CONF_END_TIME, CONF_END_TIME_ACTION, CONF_END_TIME_ACTION))
         self.log_config()
     
    
@@ -1174,7 +1159,7 @@ class Model:
         )
         self.update(end_time=parsed_end)
         # must be down here to make sure new callback is set regardless of exceptions
-        self.do_transition_behaviour(CONF_END_TIME_ACTION)
+        self.do_transition_behaviour(CONF_ON_ENTER_CONSTRAINED)
         self.constrain()
 
     @callback
@@ -1204,7 +1189,7 @@ class Model:
             self.blocked()
         else:
             self.enable()
-        self.do_transition_behaviour(CONF_START_TIME_ACTION)
+        self.do_transition_behaviour(CONF_ON_EXIT_CONSTRAINED)
 
     # =====================================================
     #    H E L P E R   F U N C T I O N S        ( N E W )

--- a/custom_components/entity_controller/const.py
+++ b/custom_components/entity_controller/const.py
@@ -11,6 +11,21 @@ SERVICE_SET_NIGHT_MODE = "set_night_mode"
 #configuration
 CONF_START_TIME = 'start_time'
 CONF_END_TIME = 'end_time'
+
+# Transition Behaviours
+CONF_BEHAVIOURS = 'behaviours'
+
+CONF_ON_ENTER_IDLE='on_enter_idle'
+CONF_ON_EXIT_IDLE='on_exit_idle'
+CONF_ON_ENTER_ACTIVE='on_enter_active'
+CONF_ON_EXIT_ACTIVE='on_exit_active'
+CONF_ON_ENTER_OVERRIDDEN = 'on_enter_overidden'
+CONF_ON_EXIT_OVERRIDDEN = 'on_exit_overidden'
+CONF_ON_ENTER_CONSTRAINED = 'on_enter_constrained'
+CONF_ON_EXIT_CONSTRAINED = 'on_exit_constrained'
+CONF_ON_ENTER_BLOCKED = 'on_enter_blocked'
+CONF_ON_EXIT_BLOCKED = 'on_exit_blocked'
+
 CONF_END_TIME_ACTION = 'end_time_action'
 CONF_START_TIME_ACTION = 'start_time_action'
 CONF_TRANSITION_BEHAVIOUR_ON = 'on'

--- a/custom_components/entity_controller/const.py
+++ b/custom_components/entity_controller/const.py
@@ -43,8 +43,6 @@ CONF_ON_EXIT_CONSTRAINED = 'on_exit_constrained'
 CONF_ON_ENTER_BLOCKED = 'on_enter_blocked'
 CONF_ON_EXIT_BLOCKED = 'on_exit_blocked'
 
-CONF_END_TIME_ACTION = 'end_time_action'
-CONF_START_TIME_ACTION = 'start_time_action'
 CONF_TRANSITION_BEHAVIOUR_ON = 'on'
 CONF_TRANSITION_BEHAVIOUR_OFF = 'off'
 CONF_TRANSITION_BEHAVIOUR_IGNORE = 'ignore'

--- a/custom_components/entity_controller/const.py
+++ b/custom_components/entity_controller/const.py
@@ -1,3 +1,20 @@
+"""
+This file is part of Entity Controller.
+
+Entity Controller is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Entity Controller is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Entity Controller.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
 """ Constants used by other files """
 
 DOMAIN = "entity_controller"

--- a/custom_components/entity_controller/entity_services.py
+++ b/custom_components/entity_controller/entity_services.py
@@ -1,3 +1,20 @@
+"""
+This file is part of Entity Controller.
+
+Entity Controller is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Entity Controller is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Entity Controller.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
 """ Entity Service Definitions """
 
 import voluptuous as vol


### PR DESCRIPTION
This PR implements transition behaviours as to allow some change to the behaviour. Cleans up implemention added in v6.0.0 and extends the number of transition points.

The behaviour implemented with `end_time_action` and `start_time_action` has been replaced with a more generic callback to make it the same as the other callbacks.

```
    behaviours:
      on_enter_constrain: "ignore"
      on_exit_constrain: "ignore"

```
Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop` 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [ ] README documentation is updated for new features (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues.

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project owners to license your work under the terms of the MIT License.

## Description

## Related Issues

Closes #154
