### PR TITLE
Change mdi:timer* to mdi:timer*-outline in prep for HA 0.115

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -387,11 +387,11 @@ class EntityController(entity.Entity):
         if self.model.state == "active":
             return "mdi:check-circle"
         if self.model.state == "active_timer":
-            return "mdi:timer"
+            return "mdi:timer-outline"
         if self.model.state == "constrained":
             return "mdi:cancel"
         if self.model.state == "overridden":
-            return "mdi:timer-off"
+            return "mdi:timer-off-outline"
         if self.model.state == "blocked":
             return "mdi:close-circle"
         return "mdi:eye"


### PR DESCRIPTION
Thank you for contributing!

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop` 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [x] README documentation is updated for new features (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [x] Description explains the issue/use-case resolved and auto-closes related issues.

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project owners to license your work under the terms of the MIT License.

## Description

Fix mdi icon names introduced in 0.113 and due to be removed in 0.115 https://www.home-assistant.io/blog/2020/07/22/release-113/#mdi-icons-updated


## Related Issues

Closes n/a
