### PR TITLE
fix: Apply all EC configurations in HA config packages

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -164,14 +164,11 @@ async def async_setup(hass, config):
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    myconfig = config[DOMAIN][0]
-
     _LOGGER.info(
         "If you have ANY issues with EntityController (v"
         + VERSION
         + "), please enable DEBUG logging under the logger component and kindly report the issue on Github. https://github.com/danobot/entity-controller/issues"
     )
-    _LOGGER.info("Domain Configuration: " + str(myconfig))
 
     async_setup_entity_services(component)
 
@@ -330,17 +327,19 @@ async def async_setup(hass, config):
     # Enter blocked state when component is enabled and entity is on
     machine.add_transition(trigger="blocked", source="constrained", dest="blocked")
 
-    for key, config in myconfig.items():
-        if not config:
-            config = {}
+    for myconfig in config[DOMAIN]:
+        _LOGGER.info("Domain Configuration: " + str(myconfig))
+        for key, config in myconfig.items():
+            if not config:
+                config = {}
 
-        # _LOGGER.info("Config Item %s: %s", str(key), str(config))
-        config["name"] = key
-        m = None
-        m = EntityController(hass, config, machine)
-        # machine.add_model(m.model)
-        # m.model.after_model(config)
-        devices.append(m)
+            # _LOGGER.info("Config Item %s: %s", str(key), str(config))
+            config["name"] = key
+            m = None
+            m = EntityController(hass, config, machine)
+            # machine.add_model(m.model)
+            # m.model.after_model(config)
+            devices.append(m)
 
     await component.async_add_entities(devices)
 


### PR DESCRIPTION
Thank you for contributing!

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop` 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [ ] README documentation is updated for new features or changes in behaviour to existing features (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [x] Description explains the issue/use-case resolved and auto-closes related issues.
- [ ] Breaking changes or changes in behaviour are called out and discussed in separate issues.

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license.

## Description

Fix support for [packages](https://www.home-assistant.io/docs/configuration/packages/) in HA configuration by iterating all `entity_controller:` keys. This allows users to separate the EC configuration into multiple files.

A basic configuration example follows.

`configuration.yaml`:
```yaml
homeassistant:
  packages: !include_dir_named packages
```

`packages/room1.yaml`:
```yaml
entity_controller:
  room1_ec:
    sensors:
      - binary_sensor.room1
    entities:
      - light.room1
```

`packages/room2.yaml`:
```yaml
entity_controller:
  room2_ec:
    sensors:
      - binary_sensor.room2
    entities:
      - light.room2
```

## Related Issues

Closes
