### PR TITLE
feat: Allow 'ignored_event_sources' to contain Regex patterns to support integrations with dynamic context ids

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -595,7 +595,12 @@ class Model:
             str(old),
             str(new)
         )
-        if new.context.id == self.context.id or new.context.id in self.ignored_event_sources:
+        def regex_match(context_id):
+            return any(
+                re.match(pattern + r"\b", context_id) is not None
+                for pattern in self.ignored_event_sources
+            )
+        if new.context.id == self.context.id or regex_match(new.context.id):
             self.log.debug("state_entity_state_change :: Ignoring this state change because it came from %s" % (new.context.id))
             return
 


### PR DESCRIPTION
This is after a request here https://github.com/home-assistant/core/pull/40626#issuecomment-709373896.

Closes https://github.com/danobot/entity-controller/issues/205

@broyuken, I don't use this integration, could you test if this works with the pattern `adapt_lgt_.*`.

Also, could you add documentation for this feature?

Thank you for contributing!

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop` 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [x] README documentation is updated for new features or changes in behaviour to existing features (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [x] Description explains the issue/use-case resolved and auto-closes related issues.
- [x] Breaking changes or changes in behaviour are called out and discussed in separate issues.

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license.

## Description

## Related Issues

Closes
