### PR TITLE
fix: HA does not need to poll EC for state

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -446,6 +446,10 @@ class EntityController(entity.Entity):
         """Register update dispatcher."""
         self.may_update = True
 
+    @property
+    def should_poll(self) -> bool:
+        """EntityController will push its state to HA"""
+        return False
 
 class Model:
     """ Represents the transitions state machine model """


### PR DESCRIPTION
## Description
Override `entity.Entity.should_poll` to indicate that Home Assistant does not need to poll Entity Controller entities for state changes.

## Checklist

- [ ] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [ ] Double-check your branch is based on `develop` and targets `develop` 
- [ ] Issue raised to compliment this PR (if no pre-existing issue exists)
- [ ] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [ ] Documentation repository updated to reflect new features or changes in behaviour (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues.
- [ ] Breaking changes or changes in behaviour are called out and discussed in separate issues.
- [ ] Testing of new changes completed by person who raised the issue.

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues

Closes

