### PR TITLE
fix: Exceptions due to services not loaded during EC startup

### DIFF
--- a/custom_components/entity_controller/manifest.json
+++ b/custom_components/entity_controller/manifest.json
@@ -7,6 +7,10 @@
   ],
   "dependencies": [
   ],
+  "after_dependencies": [
+    "light",
+    "script"
+  ],
   "codeowners": ["@danobot"],
   "homeassistant": "0.102.3"
 }


### PR DESCRIPTION
## Description
Add `after_dependencies` on the most commonly used control entity components to prevent attempts to use them during startup before they have been initialised. This fixes `ServiceNotFound` with `Unable to find service light/turn_on` and `Unable to find service script/turn_on`.

## Checklist

- [ ] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [ ] Double-check your branch is based on `develop` and targets `develop` 
- [ ] Issue raised to compliment this PR (if no pre-existing issue exists)
- [ ] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [ ] Documentation repository updated to reflect new features or changes in behaviour (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues.
- [ ] Breaking changes or changes in behaviour are called out and discussed in separate issues.
- [ ] Testing of new changes completed by person who raised the issue.

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues

Closes

