### PR TITLE
fix: ignore sensor attribute only state changes

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -551,9 +551,9 @@ class Model:
             if new.state == old.state:
                 self.log.debug("sensor_state_change :: Ignore attribute only change")
                 return
-        except Exception as e:
-            self.log.debug("sensor_state_change :: old or new state: %s" , e)
-            return
+        except AttributeError:
+            self.log.debug("sensor_state_change :: old NoneType")
+            pass
 
         if self.matches(new.state, self.SENSOR_ON_STATE) and (
             self.is_idle() or self.is_active_timer() or self.is_blocked()

--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -547,6 +547,14 @@ class Model:
         self.log.debug("sensor_state_change :: %10s Sensor state change to: %s" % ( pprint.pformat(entity), new.state))
         self.log.debug("sensor_state_change :: state: " +  pprint.pformat(self.state))
 
+        try:
+            if new.state == old.state:
+                self.log.debug("sensor_state_change :: Ignore attribute only change")
+                return
+        except Exception as e:
+            self.log.debug("sensor_state_change :: old or new state: %s" , e)
+            return
+
         if self.matches(new.state, self.SENSOR_ON_STATE) and (
             self.is_idle() or self.is_active_timer() or self.is_blocked()
         ):


### PR DESCRIPTION
## Description
When a zigbee2mqtt and zwave2mqtt motion sensor changes from motion to no motion detected it triggers two state changes:
the first only attribute changes with both old and new state: on
immediately follow by a second one where the state changes from on to off
the first is seen by EC as sensor on state change which gives unexpected results

## Checklist

- [x] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [x] Double-check your branch is based on `develop` and targets `develop` 
- [x] Issue raised to compliment this PR (if no pre-existing issue exists)
- [x] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [x] Description explains the issue/use-case resolved and auto-closes related issues.
- [x] Testing of new changes completed by person who raised the issue.


## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues

Closes
#58
#227


