### PR TITLE
Add an "activate" service to manually activate an entity controller

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -193,6 +193,15 @@ async def async_setup(hass, config):
         dest="overridden",
     )
 
+    machine.add_transition(
+        trigger="activate",
+        source=["idle", "blocked"],
+        dest="active",
+    )
+    machine.add_transition(
+        trigger="activate", source="active_timer", dest=None, after="_reset_timer"
+    )
+
     # Idle
     # machine.add_transition(trigger='sensor_off',           source='idle',              dest=None)
     machine.add_transition(
@@ -356,6 +365,7 @@ async def async_setup(hass, config):
 
 class EntityController(entity.Entity):
     from .entity_services import (
+        async_entity_service_activate as async_activate,
         async_entity_service_clear_block as async_clear_block,
         async_entity_service_enable_stay_mode as async_enable_stay_mode,
         async_entity_service_disable_stay_mode as async_disable_stay_mode,

--- a/custom_components/entity_controller/const.py
+++ b/custom_components/entity_controller/const.py
@@ -21,6 +21,7 @@ DOMAIN = "entity_controller"
 DOMAIN_SHORT = "ec"
 
 # services
+SERVICE_ACTIVATE = "activate"
 SERVICE_CLEAR_BLOCK = "clear_block"
 SERVICE_ENABLE_STAY_MODE = "enable_stay_mode"
 SERVICE_DISABLE_STAY_MODE = "disable_stay_mode"

--- a/custom_components/entity_controller/entity_services.py
+++ b/custom_components/entity_controller/entity_services.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
 import homeassistant.util.dt as dt_util
 
 from .const import (
+    SERVICE_ACTIVATE,
     SERVICE_CLEAR_BLOCK,
     SERVICE_ENABLE_STAY_MODE,
     SERVICE_DISABLE_STAY_MODE,
@@ -48,6 +49,7 @@ def async_setup_entity_services(component: EntityComponent):
     """ Setup Entity services."""
 
     component.logger.debug("Setting up entity services")
+    component.async_register_entity_service(SERVICE_ACTIVATE, {}, "async_activate")
     component.async_register_entity_service(SERVICE_CLEAR_BLOCK, {}, "async_clear_block")
     component.async_register_entity_service(SERVICE_ENABLE_STAY_MODE, {}, "async_enable_stay_mode")
     component.async_register_entity_service(SERVICE_DISABLE_STAY_MODE, {}, "async_disable_stay_mode")
@@ -57,6 +59,15 @@ def async_setup_entity_services(component: EntityComponent):
         "async_set_night_mode")
 
     return True
+
+def async_entity_service_activate(self):
+    """ Activates the entity controller"""
+
+    if(self.model is None):
+        return
+
+    self.model.log.debug("Activating the Entity Controller")
+    self.model.activate()
 
 def async_entity_service_clear_block(self):
     """ Clear the block property, if set"""

--- a/custom_components/entity_controller/services.yaml
+++ b/custom_components/entity_controller/services.yaml
@@ -1,3 +1,11 @@
+activate:
+  description: Activates an Entity Controller. Turns on the entity and transitions
+    to the active_timer state. This also clears the blocked state if set.
+  fields:
+    entity_id:
+      description: Name(s) of entities to trigger.
+      example: 'entity_controller.motion_light'
+
 clear_block:
   description: Clears the blocked state of an Entity Controller, if set
   fields:


### PR DESCRIPTION
## Description

I've added an `entity_controller.activate` service that can be used to manually activate an entity controller. This will transition from `idle` or `blocked` into `active`. It will also reset the timer if the state is already `active_timer`.

I am going to be using this to set up scheduled automations for devices around my house. For example, I will call this service to turn on our heated towel rails at 6am so that our towels are warm in the morning, and I will use the entity controller timer to turn off the heated towel rail after the timer expires. I also have a humidity sensor configured as a "hygrostat". This is a sensor that activates the entity controller and turns on the heated towel rails whenever someone is in the shower. So I want the scheduled timer and hygrostat to work together with an `active_timer` state, instead of going into a `blocked` state.

Another example is turning on my office thermostat before I wake up, so that my office is warm before I start work. I don't want to leave my heater on all day if I'm not in there, so I have this on a 30 minute timer. However, it takes about an hour and 30 minutes to heat up my office (from 16℃ to 24℃.) So I will turn on the thermostat directly at 7am, and then call `entity_controller.activate` at 8:30am to start the timer for another 30 minutes. If I then go into my office, the door or motion sensor will restart the timer. And then if my computer becomes active, this overrides the entity controller and prevents it from turning off the thermostat. It would be quite difficult to achieve this logic without this new `entity_controller.activate` service.

I've tested this new feature by installing my repo in HACS, and it's working great.

## Checklist

- [x] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [x] Double-check your branch is based on `develop` and targets `develop` 
- [x] Issue raised to compliment this PR (if no pre-existing issue exists)
- [x] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [x] Documentation repository updated to reflect new features or changes in behaviour (VERY IMPORTANT, undocumented features cannot be discovered and used!)
  - Documentation PR: https://github.com/danobot/ec-docs/pull/5
- [x] Description explains the issue/use-case resolved and auto-closes related issues.
- [x] Breaking changes or changes in behaviour are called out and discussed in separate issues.
- [x] Testing of new changes completed by person who raised the issue.


## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues

Closes #267

