### PR TITLE
Add possibility to manually enable blocked state

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -328,6 +328,9 @@ async def async_setup(hass, config):
     # When block is disabled, "control" will reset the active timer
     machine.add_transition(trigger="control", source="active_timer",
                            dest=None, after="_reset_timer", conditions=["is_state_entities_on"], unless="is_block_enabled")
+    # Manually enable blocked state
+    machine.add_transition(trigger="block_enable", source="active_timer",
+                           dest="blocked", conditions=["is_state_entities_on", "is_block_enabled"])
 
     # machine.add_transition(trigger='sensor_off',           source='active_stay_on',    dest=None)
     # machine.add_transition(trigger="timer_expires", source="active_stay_on", dest=None)
@@ -378,6 +381,7 @@ class EntityController(entity.Entity):
     from .entity_services import (
         async_entity_service_activate as async_activate,
         async_entity_service_clear_block as async_clear_block,
+        async_entity_service_enable_block as async_enable_block,
         async_entity_service_enable_stay_mode as async_enable_stay_mode,
         async_entity_service_disable_stay_mode as async_disable_stay_mode,
         async_entity_service_set_night_mode as async_set_night_mode,

--- a/custom_components/entity_controller/const.py
+++ b/custom_components/entity_controller/const.py
@@ -23,6 +23,7 @@ DOMAIN_SHORT = "ec"
 # services
 SERVICE_ACTIVATE = "activate"
 SERVICE_CLEAR_BLOCK = "clear_block"
+SERVICE_ENABLE_BLOCK = "enable_block"
 SERVICE_ENABLE_STAY_MODE = "enable_stay_mode"
 SERVICE_DISABLE_STAY_MODE = "disable_stay_mode"
 SERVICE_SET_NIGHT_MODE = "set_night_mode"

--- a/custom_components/entity_controller/entity_services.py
+++ b/custom_components/entity_controller/entity_services.py
@@ -36,6 +36,7 @@ import homeassistant.util.dt as dt_util
 from .const import (
     SERVICE_ACTIVATE,
     SERVICE_CLEAR_BLOCK,
+    SERVICE_ENABLE_BLOCK,
     SERVICE_ENABLE_STAY_MODE,
     SERVICE_DISABLE_STAY_MODE,
     SERVICE_SET_NIGHT_MODE,
@@ -51,6 +52,7 @@ def async_setup_entity_services(component: EntityComponent):
     component.logger.debug("Setting up entity services")
     component.async_register_entity_service(SERVICE_ACTIVATE, {}, "async_activate")
     component.async_register_entity_service(SERVICE_CLEAR_BLOCK, {}, "async_clear_block")
+    component.async_register_entity_service(SERVICE_ENABLE_BLOCK, {}, "async_enable_block")
     component.async_register_entity_service(SERVICE_ENABLE_STAY_MODE, {}, "async_enable_stay_mode")
     component.async_register_entity_service(SERVICE_DISABLE_STAY_MODE, {}, "async_disable_stay_mode")
     component.async_register_entity_service(
@@ -77,6 +79,15 @@ def async_entity_service_clear_block(self):
 
     self.model.log.debug("Clearing Blocked state")
     self.model.block_timer_expires()
+
+def async_entity_service_enable_block(self):
+    """ Enable the block property, if timer is active"""
+
+    if(self.model is None or self.model.state != 'active_timer'):
+        return
+
+    self.model.log.debug("Enabling Blocked state")
+    self.model.block_enable()
 
 def async_entity_service_enable_stay_mode(self):
     self.model.log.debug("Enable stay mode - Control entities will remain on until manually turned off")

--- a/custom_components/entity_controller/services.yaml
+++ b/custom_components/entity_controller/services.yaml
@@ -13,6 +13,13 @@ clear_block:
       description: Name(s) of entities to change.
       example: 'entity_controller.motion_light'
 
+enable_block:
+  description: Enables the blocked state of an Entity Controller, if timer is active
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'entity_controller.motion_light'
+
 set_stay_on:
   description: Change the stay to on
   fields:


### PR DESCRIPTION
## Description

This pull requests adds `entity_controller.enable_block` service that allows to manually enable blocked state.

  Thanks to this feature it will be possible to prevent entity from being automatically turned off - in my use case I use it to block light in a bathroom when its door is closed and a presence of a person inside is detected (e.g. by clicking a button).

## Checklist

- [x] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [x] Double-check your branch is based on `develop` and targets `develop` 
- [x] Issue raised to compliment this PR (if no pre-existing issue exists)
- [x] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [ ] Documentation repository updated to reflect new features or changes in behaviour (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [x] Description explains the issue/use-case resolved and auto-closes related issues.
- [x] Breaking changes or changes in behaviour are called out and discussed in separate issues.
- [x] Testing of new changes completed by person who raised the issue.

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues

Closes #237 

