### PR TITLE
Ignore state change events while Home Assistant is starting and initializing entity states, override controllers correctly on startup

### DIFF
--- a/custom_components/entity_controller/const.py
+++ b/custom_components/entity_controller/const.py
@@ -81,7 +81,7 @@ MODE_DAY = 'day'
 MODE_NIGHT = 'night'
 CONSTRAIN_START = 1
 CONSTRAIN_END = 2
-STATES = ['idle', 'overridden', 'constrained', 'blocked',
+STATES = ['pending', 'idle', 'overridden', 'constrained', 'blocked',
           {'name': 'active', 'children': ['timer', 'stay_on'],
            'initial': False}]
 CONF_IGNORE_STATE_CHANGES_UNTIL = "grace_period"


### PR DESCRIPTION
* Ignore state change events for 70 seconds after starting
* Check overrides 65 seconds after starting (when entity states should be ready)

Not sure about the hardcoded `STARTUP_DELAY = 70`, since every installation will have different startup times and entities from different integrations. This is probably quite specific to my HA instance running on a server, and with most of my entities coming from Zigbee2MQTT. I also wouldn't want to need to configure this for every single entity controller instance. Not sure if there's a nice way to make this configurable.

## Description

This fixes an annoying issue I've experienced where I can't work on my HA config or perform upgrades late at night, because it would always turn on the bedroom lights while my wife was sleeping.

## Checklist

- [X] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [X] Double-check your branch is based on `develop` and targets `develop` 
- [X] Issue raised to compliment this PR (if no pre-existing issue exists)
- [X] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [ ] Documentation repository updated to reflect new features or changes in behaviour (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [X] Description explains the issue/use-case resolved and auto-closes related issues.
- [ ] Breaking changes or changes in behaviour are called out and discussed in separate issues.
- [ ] Testing of new changes completed by person who raised the issue.

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues

Closes #285 
Also: #231

