### PR TITLE
feat: warn about mismatched timezones #311

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -173,10 +173,10 @@ PLATFORM_SCHEMA = cv.schema_with_slug_keys(ENTITY_SCHEMA)
 async def async_setup(hass, config):
     """Load graph configurations."""
 
-    if(((datetime.now()).astimezone()).tzinfo != dt.as_local(dt.now()).tzinfo):
+    if(str(((datetime.now()).astimezone()).tzinfo) != str(dt.as_local(dt.now()).tzname())):
         _LOGGER.error("Timezones do not Match. Mismatched timezones may cause unintended behaviours.")
         _LOGGER.error("System DateTime: %s", ((datetime.now()).astimezone()).tzinfo )
-        _LOGGER.error("Home Assistant DateTime: %s", dt.as_local(dt.now()).tzinfo )
+        _LOGGER.error("Home Assistant DateTime: %s", dt.as_local(dt.now()).tzname())
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 

--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -174,9 +174,9 @@ async def async_setup(hass, config):
     """Load graph configurations."""
 
     if(((datetime.now()).astimezone()).tzinfo != dt.as_local(dt.now()).tzinfo):
-        _LOGGER.error("Timezones do not Match")
-        _LOGGER.error("DateTime: %s", ((datetime.now()).astimezone()).tzinfo )
-        _LOGGER.error("HA DT: %s", dt.as_local(dt.now()).tzinfo )
+        _LOGGER.error("Timezones do not Match. Mismatched timezones may cause unintended behaviours.")
+        _LOGGER.error("System DateTime: %s", ((datetime.now()).astimezone()).tzinfo )
+        _LOGGER.error("Home Assistant DateTime: %s", dt.as_local(dt.now()).tzinfo )
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 

--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -173,6 +173,11 @@ PLATFORM_SCHEMA = cv.schema_with_slug_keys(ENTITY_SCHEMA)
 async def async_setup(hass, config):
     """Load graph configurations."""
 
+    if(((datetime.now()).astimezone()).tzinfo != dt.as_local(dt.now()).tzinfo):
+        _LOGGER.error("Timezones do not Match")
+        _LOGGER.error("DateTime: %s", ((datetime.now()).astimezone()).tzinfo )
+        _LOGGER.error("HA DT: %s", dt.as_local(dt.now()).tzinfo )
+
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     _LOGGER.info(


### PR DESCRIPTION
## Description
With this pull request i want to introduce a error message, if the home assistant and system timezones are mismatched.
This may cause the start_time_callback function to get called repeatedly.

With this change the user should become aware, that their current configuration might be an issue.

## Checklist

- [x ] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [x ] Double-check your branch is based on `develop` and targets `develop` 
- [x ] Issue raised to compliment this PR (if no pre-existing issue exists)
- [ ] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [ ] Documentation repository updated to reflect new features or changes in behaviour (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [x ] Description explains the issue/use-case resolved and auto-closes related issues.
- [ ] Breaking changes or changes in behaviour are called out and discussed in separate issues.
- [x ] Testing of new changes completed by person who raised the issue.

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues
#311

Closes

