### PR TITLE
Fix: Allow remaining entites to be checked, when one is potential configuartion error #313

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -767,7 +767,8 @@ class Model:
                         e, ex
                     )
                 )
-                return None
+                
+                continue
 
             if self.matches(state, self.OVERRIDE_ON_STATE):
                 self.log.debug("Override entities are ON. [%s]", e)
@@ -797,7 +798,8 @@ class Model:
                         e, ex
                     )
                 )
-                return None
+                
+                continue
 
             if self.matches(state, self.SENSOR_ON_STATE):
                 self.log.debug("Sensor entities are ON. [%s]", e)
@@ -823,8 +825,8 @@ class Model:
                         e, ex
                     )
                 )
-                state = 'off'
-                return None
+                
+                continue
 
             if self.matches(state, self.STATE_ON_STATE):
                 self.log.debug("State entities are ON. [%s]", e)


### PR DESCRIPTION
## Description
By returning None in except block, checking of remaining entities is prevented, even if there are functinoal one behind the broken on in the list.

By jumping skipping the rest of the loop, checking of the remaining entities is allowed, while the normal behaviour remains the same.

## Checklist

- [x] The PR title is clear, concise and follows [`conventional commit`](https://www.conventionalcommits.org) formatting.
- [x] Double-check your branch is based on `develop` and targets `develop` 
- [x] Issue raised to compliment this PR (if no pre-existing issue exists)
- [ ] Code is commented, particularly in hard-to-understand areas and relevant issues are referenced.
- [ ] Documentation repository updated to reflect new features or changes in behaviour (VERY IMPORTANT, undocumented features cannot be discovered and used!)
- [x] Description explains the issue/use-case resolved and auto-closes related issues.
- [ ] Breaking changes or changes in behaviour are called out and discussed in separate issues.
- [x] Testing of new changes completed by person who raised the issue.

**Please open an issue** before embarking on any significant pull request, especially those that add a new library or change existing tests, otherwise you risk spending a lot of time working on something that might not end up being merged into the project.

## License
By submitting a patch, you agree to allow the project owners to license your work under the terms of the project license. Thank you for contributing!

## Related Issues
#313

Closes

