### PR TITLE
fix(time): futurize() must compare in HA-local wall time, not OS timezone

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -1690,12 +1690,24 @@ class Model:
 
         # self.log.debug("-------------------- futurize ------------------------")
         # self.log.debug("Input (naive) %s ", timet)
-        today = date.today()
+        # Compare in HA-local wall time, NOT the process timezone: parse_time()
+        # returns naive times in the HA-configured timezone, while
+        # datetime.now()/date.today() follow the OS timezone. When the two
+        # differ (e.g. host on UTC, HA on Europe/Prague), a just-fired callback
+        # rescheduled itself to a time that is "future" in OS terms but already
+        # past in HA-local terms — async_track_point_in_time then fires it
+        # again immediately, in an endless loop (2026-07-09 incident: sunrise
+        # end_time callbacks re-fired for exactly the UTC-offset window,
+        # flooding MQTT with turn_off commands).
+        now_local = dt.as_local(dt.now()).replace(tzinfo=None)
+        today = now_local.date()
         try:
             t = datetime.combine(today, timet)
         except TypeError as e:
             t = timet
-        x = datetime.now()
+        if t.tzinfo is not None:
+            t = dt.as_local(t).replace(tzinfo=None)
+        x = now_local
         # self.log.debug("input time: " + str(t))
 
         # self.log.debug("current time: " + str(x))


### PR DESCRIPTION
## Problem

`Model.futurize()` builds the reference "today"/"now" from `date.today()` / `datetime.now()`, which follow the **OS/process** timezone. The times it compares against come from `parse_time()` and are naive values in the **HA-configured** timezone. When the two differ (e.g. host on UTC, Home Assistant on `Europe/Prague`), a time-based callback that has just fired reschedules itself to an instant that is still "in the future" in OS-local terms but already in the past in HA-local terms. `async_track_point_in_time` then fires it again immediately, and the callback re-arms itself in a tight loop.

In practice this showed up as `end_time`/sunrise callbacks re-firing continuously for exactly the UTC-offset-sized window, flooding MQTT with repeated `turn_off` commands until the offset window elapsed.

This bites any deployment where the container/host timezone is not the same as the HA timezone (common on NixOS/containerized installs that keep the host on UTC).

## Fix

Anchor both sides of the comparison to HA-local wall time using `homeassistant.util.dt` (already imported at module top):

```python
now_local = dt.as_local(dt.now()).replace(tzinfo=None)
today = now_local.date()
...
if t.tzinfo is not None:
    t = dt.as_local(t).replace(tzinfo=None)
x = now_local
```

No behavior change when host TZ == HA TZ.

## Testing

Deployed on an installation with host=UTC / HA=Europe/Prague; the callback re-fire loops / MQTT command floods around sunrise are gone, and normal time-restriction scheduling is unaffected.