### PR TITLE
fix(state-machine): catch-all block_timer_expires -> idle to prevent stuck-in-blocked

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -330,6 +330,18 @@ async def async_setup(hass, config):
         dest="idle",
         conditions=["is_state_entities_on", "is_duration_sensor", "is_sensor_off"],
     )
+    # Catch-all: block_timer_expires -> idle for every case the conditional
+    # transitions above do not handle. Without it the controller stays stuck in
+    # `blocked` past its block_timeout when the timer fires and state entities
+    # are still reported as on (e.g. slow cloud/gateway feedback from
+    # integrations like Overkiz/Tahoma) while the trigger sensor is already off,
+    # or when state entities are off but no earlier transition matches. Added
+    # last so the conditional "go to active" rules are evaluated first.
+    machine.add_transition(
+        trigger="block_timer_expires",
+        source="blocked",
+        dest="idle",
+    )
 
     # Active Timer
     machine.add_transition(


### PR DESCRIPTION
## Problem

When `block_timer_expires` fires, danobot only defines conditional `blocked`-source transitions (all requiring `is_state_entities_on`, going to `active` or `idle`). If none match, the controller stays stuck in `blocked` **indefinitely** past its `block_timeout`. Two real cases hit this:

1. State entities are still reported `on` (slow cloud/gateway feedback from integrations like Overkiz/Tahoma) while the trigger sensor has already turned off — no conditional transition matches.
2. State entities are already off — again nothing matches.

Note the file already carries a commented-out unconditional transition (`# machine.add_transition(trigger='block_timer_expires', source='blocked', dest='idle')`), i.e. this fallback was intended but disabled.

## Fix

Re-add the unconditional `blocked -> idle` transition, placed **after** the conditional "go to active" transitions so those still win when their conditions hold. It acts as a guaranteed fallback for every other case, so the controller always leaves `blocked` when the timer fires.

## Testing

Deployed on a setup with an Overkiz/Somfy gateway that returns stale `on` feedback at sunrise; controllers previously stuck in `blocked` until an HA restart now return to `idle` when the block timer expires.