### PR TITLE
fix(state-machine): allow blocked from idle at start_time; never raise from the callback

### DIFF
--- a/custom_components/entity_controller/__init__.py
+++ b/custom_components/entity_controller/__init__.py
@@ -43,6 +43,7 @@ from homeassistant.util import dt
 import homeassistant.util.yaml.objects as YamlObjects
 import homeassistant.util.uuid as uuid_util
 from transitions import Machine
+from transitions.core import MachineError
 from transitions.extensions import HierarchicalMachine as Machine
 from homeassistant.helpers.service import async_call_from_config
 
@@ -370,6 +371,13 @@ async def async_setup(hass, config):
     )
     # Enter blocked state when component is enabled and entity is on
     machine.add_transition(trigger="blocked", source="constrained", dest="blocked", conditions=["is_block_enabled"])
+    # blocked must also be reachable from idle: start_time_callback fires while
+    # the machine is already idle (HA restarted inside the active window, or an
+    # override toggled off before start_time) and calls blocked() when state
+    # entities are on. Without this transition that raises MachineError and HA
+    # keeps re-firing the failed point-in-time callback (error storm). Mirrors
+    # the existing sensor_on: idle -> blocked rule.
+    machine.add_transition(trigger="blocked", source="idle", dest="blocked", conditions=["is_block_enabled"])
 
     for myconfig in config[DOMAIN]:
         _LOGGER.info("Domain Configuration: " + str(myconfig))
@@ -1261,13 +1269,31 @@ class Model:
 
         self.update(start_time=parsed_start)
 
-        if self.is_state_entities_on() and self.is_block_enabled():
-            self.blocked()
-        else:
-            # If the entity is on and block is disabled, we just transition from constrained
-            # to idle and leave the entity on. (Don't start a timer to turn it off.)
-            self.enable()
+        self._apply_start_time_transition()
         self.do_transition_behaviour(CONF_ON_EXIT_CONSTRAINED)
+
+    def _apply_start_time_transition(self):
+        """Transition the machine when start_time is reached.
+
+        Must never raise: an exception escaping a point-in-time callback makes
+        HA re-fire it endlessly (error storm). States with no defined
+        transition from here (e.g. overridden/active after a mid-window HA
+        restart) are logged and left unchanged -- the next sensor/override
+        event resolves the controller normally.
+        """
+        try:
+            if self.is_state_entities_on() and self.is_block_enabled():
+                self.blocked()
+            else:
+                # If the entity is on and block is disabled, we just transition from constrained
+                # to idle and leave the entity on. (Don't start a timer to turn it off.)
+                self.enable()
+        except MachineError as err:
+            self.log.warning(
+                "start_time_callback :: no transition from state '%s' (%s); leaving state unchanged",
+                self.state,
+                err,
+            )
 
     # =====================================================
     #    H E L P E R   F U N C T I O N S        ( N E W )


### PR DESCRIPTION
## Problem

`start_time_callback()` unconditionally calls `blocked()` (or `enable()`) whenever `start_time` is reached. But the machine is not always in `constrained` at that moment:

- HA restarts **inside** the active window → machine is `idle` at `start_time`.
- an override toggles off before `start_time` → also `idle`.

danobot defines `blocked` only from `constrained` (and the self/`sensor_on` rules), so `blocked()` from `idle` raises `transitions.core.MachineError`. Because the exception escapes a `async_track_point_in_time` callback, HA **re-fires the failed callback endlessly**, producing a log/error storm.

## Fix

1. Add a `blocked: idle -> blocked` transition (guarded by `is_block_enabled`), mirroring the existing `sensor_on: idle -> blocked` rule.
2. Extract the start-time logic into `_apply_start_time_transition()` and wrap it in `try/except MachineError`, so any state with no defined transition from `start_time` is logged and left unchanged instead of raising out of the point-in-time callback. This makes the callback robust to future state/transition gaps as well.

`from transitions.core import MachineError` added to imports.

## Testing

Reproduced the error storm by restarting HA inside the active window; after the fix the controller transitions to `blocked` cleanly, and states without a transition log a single warning instead of looping. `py_compile` clean.